### PR TITLE
Add template interface tooling and capture options

### DIFF
--- a/src/gai/template_interface.py
+++ b/src/gai/template_interface.py
@@ -1,0 +1,92 @@
+"""Template interface introspection utilities."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Optional, Sequence
+
+import jinja2
+from jinja2 import meta
+
+from .exceptions import TemplateError
+from .template_catalog import TemplateRecord, resolve_template_name
+from .templates import create_jinja_env_from_catalog
+
+OUTPUT_TAG_PATTERN = re.compile(r"<(O_[A-Za-z0-9_]+)>")
+
+
+@dataclass(slots=True)
+class TemplateInterface:
+    """Describes the inferred interface of a template."""
+
+    logical_name: str
+    inputs: Mapping[str, str] = field(default_factory=dict)
+    controls: Mapping[str, str] = field(default_factory=dict)
+    mechanisms: Mapping[str, str] = field(default_factory=dict)
+    outputs: set[str] = field(default_factory=set)
+    other_variables: set[str] = field(default_factory=set)
+
+    def cli_flags_for(self, prefixed_variables: Mapping[str, str]) -> list[str]:
+        """Return sorted CLI flag representations for the provided mapping."""
+
+        flags: list[str] = []
+        for base_name in prefixed_variables.values():
+            if base_name:
+                flags.append(f"--{base_name}")
+        return sorted(set(flags))
+
+
+def build_template_interface(
+    config: Mapping[str, Any],
+    logical_name: str,
+    *,
+    catalog: Optional[Sequence[TemplateRecord]] = None,
+    jinja_env: Optional[jinja2.Environment] = None,
+) -> TemplateInterface:
+    """Build the TemplateInterface for a logical template name."""
+
+    records = list(catalog) if catalog is not None else None
+    if records is None:
+        from .template_catalog import build_template_catalog
+
+        catalog_obj = build_template_catalog(config)
+        records = list(catalog_obj.records)
+
+    if jinja_env is None:
+        jinja_env = create_jinja_env_from_catalog(records)
+
+    record = resolve_template_name(records, logical_name)
+
+    try:
+        source = record.absolute_path.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - filesystem errors are rare
+        raise TemplateError(f"Unable to read template '{logical_name}': {exc}") from exc
+
+    try:
+        ast = jinja_env.parse(source)
+    except jinja2.exceptions.TemplateSyntaxError as exc:
+        raise TemplateError(f"Unable to parse template '{logical_name}': {exc}") from exc
+
+    undeclared = meta.find_undeclared_variables(ast)
+
+    def _classify(prefix: str) -> dict[str, str]:
+        names = sorted(v for v in undeclared if v.startswith(prefix))
+        return {name: name[len(prefix) :].lstrip("_") for name in names}
+
+    inputs = _classify("I_")
+    controls = _classify("C_")
+    mechanisms = _classify("M_")
+    categorized = set(inputs) | set(controls) | set(mechanisms)
+    other_variables = {var for var in undeclared if var not in categorized}
+
+    outputs = set(OUTPUT_TAG_PATTERN.findall(source))
+
+    return TemplateInterface(
+        logical_name=logical_name,
+        inputs=inputs,
+        controls=controls,
+        mechanisms=mechanisms,
+        outputs=outputs,
+        other_variables=other_variables,
+    )

--- a/tests/test_cli_template_aliases.py
+++ b/tests/test_cli_template_aliases.py
@@ -1,0 +1,24 @@
+from gai.__main__ import _apply_user_template_override
+from gai.cli import parse_template_args_from_list
+
+
+def test_apply_user_template_override_adds_conf_flag():
+    args = ["template", "render"]
+    updated = _apply_user_template_override(args, "prompts/sample")
+
+    assert updated[-2:] == ["--conf-user-instruction-template", "prompts/sample"]
+
+
+def test_apply_user_template_override_skips_existing_flag():
+    args = ["--conf-user-instruction-template", "existing"]
+    updated = _apply_user_template_override(args, "prompts/sample")
+
+    assert updated == args
+
+
+def test_template_variable_aliases_inputs_and_controls():
+    parsed = parse_template_args_from_list(["--document", "text"])
+
+    assert parsed["document"] == "text"
+    assert parsed["I_document"] == "text"
+    assert parsed["C_document"] == "text"

--- a/tests/test_cli_template_inspect.py
+++ b/tests/test_cli_template_inspect.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+
+from gai.cli import TemplateInterface, handle_template_inspect
+
+
+def test_handle_template_inspect_outputs_sections(monkeypatch, capsys):
+    interface = TemplateInterface(
+        logical_name="prompts/sample",
+        inputs={"I_document": "document"},
+        controls={"C_style": "style"},
+        mechanisms={"M_model": "model"},
+        outputs={"O_main"},
+        other_variables={"helper"},
+    )
+
+    monkeypatch.setattr("gai.cli.build_template_interface", lambda _config, _name: interface)
+
+    parsed = SimpleNamespace(logical_name="prompts/sample")
+    handle_template_inspect({}, parsed)
+
+    captured = capsys.readouterr().out
+    assert "I_document" in captured
+    assert "O_main" in captured
+    assert "Other variables" in captured

--- a/tests/test_generation_capture_tag.py
+++ b/tests/test_generation_capture_tag.py
@@ -1,0 +1,50 @@
+from types import SimpleNamespace
+
+import pytest
+
+from gai import generation
+from gai.exceptions import GenerationError
+
+
+def test_collect_output_concatenates_chunks():
+    chunks = (SimpleNamespace(text=part) for part in ["foo", "bar"])
+
+    assert generation.collect_output(chunks) == "foobar"
+
+
+def test_extract_between_tags_success():
+    text = "pre <O_main>captured</O_main> post"
+
+    assert generation.extract_between_tags(text, "O_main") == "captured"
+
+
+def test_extract_between_tags_missing_tag():
+    with pytest.raises(GenerationError):
+        generation.extract_between_tags("no tags here", "O_main")
+
+
+def test_generate_capture_tag_writes_file(tmp_path, monkeypatch):
+    config = {
+        "model": "test-model",
+        "temperature": 0.1,
+        "response-mime-type": "text/plain",
+    }
+
+    monkeypatch.setenv("GOOGLE_API_KEY", "test")
+    monkeypatch.setattr(generation, "render_user_instruction", lambda *_: "user")
+    monkeypatch.setattr(generation, "render_system_instruction", lambda *_: "system")
+
+    def fake_execute(*_args, **_kwargs):
+        yield SimpleNamespace(text="prefix <O_main>answer</O_main> suffix")
+
+    class DummyClient:
+        def __init__(self, api_key: str):
+            self.api_key = api_key
+
+    monkeypatch.setattr(generation.genai, "Client", DummyClient)
+    monkeypatch.setattr(generation, "execute_generation_stream", fake_execute)
+
+    output_file = tmp_path / "capture.txt"
+    generation.generate(config, {}, capture_tag="O_main", output_file=str(output_file))
+
+    assert output_file.read_text(encoding="utf-8") == "answer"

--- a/tests/test_template_interface.py
+++ b/tests/test_template_interface.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import textwrap
+
+from gai.template_interface import build_template_interface
+
+
+def _base_config(root: Path) -> dict[str, list[str]]:
+    return {
+        "project-template-paths": [str(root)],
+        "user-template-paths": [],
+        "builtin-template-paths": [],
+    }
+
+
+def test_build_template_interface_detects_iocm(tmp_path):
+    template_root = tmp_path / "templates"
+    template_root.mkdir()
+    template_path = template_root / "prompts" / "sample.j2"
+    template_path.parent.mkdir(parents=True, exist_ok=True)
+    template_path.write_text(
+        textwrap.dedent(
+            """
+            {{ I_document }}
+            {{ C_style }}
+            {{ M_model }}
+            {{ helper_value }}
+            <O_main>answer</O_main>
+            """
+        ).strip()
+    )
+
+    interface = build_template_interface(_base_config(template_root), "prompts/sample")
+
+    assert interface.inputs == {"I_document": "document"}
+    assert interface.controls == {"C_style": "style"}
+    assert interface.mechanisms == {"M_model": "model"}
+    assert "helper_value" in interface.other_variables
+    assert "O_main" in interface.outputs
+
+
+def test_build_template_interface_handles_empty_sections(tmp_path):
+    template_root = tmp_path / "templates"
+    template_root.mkdir()
+    template_path = template_root / "plain.j2"
+    template_path.write_text("Static content only")
+
+    interface = build_template_interface(_base_config(template_root), "plain")
+
+    assert interface.inputs == {}
+    assert interface.controls == {}
+    assert interface.mechanisms == {}
+    assert interface.outputs == set()
+    assert interface.other_variables == set()


### PR DESCRIPTION
## Summary
- add a template interface module plus CLI support for `gai template inspect` and richer `template list` output
- improve CLI ergonomics for selecting templates, apply I/O/C aliases, and add `--capture-tag`/`--output-file` streaming controls
- document the new conventions and add dedicated unit tests for interface extraction, CLI aliases, and capture helpers

## Testing
- `pytest -o addopts=` *(fails: repository dependencies such as `jinja2`/`google-genai` are not installed in the execution environment and `pip install` is blocked)*
- `PYTHONPATH=src pytest -o addopts=` *(fails for the same missing dependency reasons as above)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691a1fe4f9488333b22770b1e7d73652)